### PR TITLE
Enable Disqus on Primer page

### DIFF
--- a/openpublishing/corefx/intro-clr.md
+++ b/openpublishing/corefx/intro-clr.md
@@ -881,3 +881,24 @@ Useful Links
 -   [Wikipedia Entry for the CLR](http://en.wikipedia.org/wiki/Common_Language_Runtime)
 -   [ECMA Standard for the Common Language Infrastructure CLI](dotnet-standards.md)
 -   [.NET Framework Design Guidelines](http://msdn.microsoft.com/en-us/library/ms229042.aspx)
+
+<!-- START: Livefyre Embed -->
+<div id="livefyre-comments"></div>
+<script type="text/javascript" src="http://zor.livefyre.com/wjs/v3.0/javascripts/livefyre.js"></script>
+<script type="text/javascript">
+  (function () {
+    var articleId = fyre.conv.load.makeArticleId(null);
+    fyre.conv.load({}, [{
+      el: 'livefyre-comments',
+      network: "livefyre.com",
+      siteId: "377988",
+      articleId: articleId,
+      signed: false,
+      collectionMeta: {
+        articleId: articleId,
+        url: fyre.conv.load.makeCollectionUrl(),
+      }
+    }], function() {});
+  }());
+</script>
+<!-- END: Livefyre Embed -->

--- a/openpublishing/corefx/primer.md
+++ b/openpublishing/corefx/primer.md
@@ -311,7 +311,7 @@ that it is important enough to highlight and discuss.
 <div id="disqus_thread"></div>
 <script type="text/javascript">
   // CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE
-  var disqus_shortname = 'openpublishinglocal'; // required: replace example with your forum shortname
+  var disqus_shortname = 'devdivcn'; // required: replace example with your forum shortname
   // DON'T EDIT BELOW THIS LINE
   (function() {
     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Update the Disqus shortsite name to use official account, and add livefyre for another page.